### PR TITLE
Hifiasm phasing transfer

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -710,7 +710,7 @@ rule split_haplotype_annotations:
     shell:
         '''
         awk -F'\t' '$2 == "HAPLOTYPE1" || $2 == "HOM" {{print $1}}' "{input}" > {output.hap1}
-        awk -F'\t' '$2 == "HAPLOTYPE1" || $2 == "HOM" {{print $1}}' "{input}" > {output.hap2}
+        awk -F'\t' '$2 == "HAPLOTYPE2" || $2 == "HOM" {{print $1}}' "{input}" > {output.hap2}
         '''
 
 rule split_assembly_for_yak:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -141,7 +141,7 @@ rule pear_merge_mates:
         mem_mb = lambda wildcards, attempt: 4096 * attempt,
         walltime = lambda wildcards, attempt: f'{attempt*attempt:02}:59:00'
     log: "log/pear_merge_mates_{sample}_{lib}.log"
-    shell: "(pear -f {input.fq1} -r {input.fq2} -t 101 -o ss/merged/{wildcards.sample}/{wildcards.lib}) > {log} 2>&1"
+    shell: "(pear -f {input.fq1} -r {input.fq2} -o ss/merged/{wildcards.sample}/{wildcards.lib}) > {log} 2>&1"
 
 rule concat_assembled_with_first_pair_of_unassembled:
     input:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -728,11 +728,24 @@ rule split_assembly_for_yak:
         seqtk subseq {input.fasta} {input.hap2_nodes} > {output.hap2}
         '''
 
-
+rule duplicate_sequences_for_yak:
+    input:
+        hap1 = temp('fasta/{sample}/{sample}_unitigs_hap1.fasta'),
+        hap2 = temp('fasta/{sample}/{sample}_unitigs_hap2.fasta')
+    output:
+        hap1=temp('fasta/{sample}/{sample}_unitigs_hap1_dup.fasta'),
+        hap2=temp('fasta/{sample}/{sample}_unitigs_hap2_dup.fasta')
+    shell:
+        '''
+        for ((i=1; i < 10; i++)); do
+            cat {input.hap1} >> {output.hap1}
+            cat {input.hap2} >> {output.hap2}
+        done
+        '''
 rule yak_count_split_fasta:
     input:
-        hap1='fasta/{sample}/{sample}_unitigs_hap1.fasta',
-        hap2='fasta/{sample}/{sample}_unitigs_hap2.fasta'
+        hap1='fasta/{sample}/{sample}_unitigs_hap1_dup.fasta',
+        hap2='fasta/{sample}/{sample}_unitigs_hap2_dup.fasta'
     output:
         hap1='yak/{sample}_hap1.yak',
         hap2='yak/{sample}_hap2.yak'


### PR DESCRIPTION
Bugfixing the reason that phasing information was lost between the output of the phasing pipeline and hifiasm. It ended uo being a bug where the yak kmer databases for each haplotype were identical, but a few other improvements were also made. The duplication of the fasta is likely helpful, but the minimum number of duplications needed to achieve a good transfer is unknown.